### PR TITLE
fixed RegEx for versioned identifiers

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -96,7 +96,7 @@ require_once('header.php');
 <p>
     With each data release a new set of IDs are created that are of the form <code>wfo-0000615907-2022-12</code>. 
     For each name the year and month of the data release are appended. 
-    A regular expression similar to <code>'/^wfo-[0-9]{10}-[0-9]{10}-[4]{2}$/'</code> will match a versioned WFO ID (depending on your precise regex implementation). 
+    A regular expression similar to <code>'/^wfo-[0-9]{10}-[0-9]{4}-[0-9]{2}$/'</code> will match a versioned WFO ID (depending on your precise regex implementation). 
 </p>
 
 <p>


### PR DESCRIPTION
This could even be further restricted to ^wfo-[0-9]{10}-20[0-9]{2}-(0[1-9]|1[0-2])$ to properly assign the YYYY-MM syntax with stability for the next 77 years.